### PR TITLE
Update of employees list after entering room

### DIFF
--- a/mobile/src/people/current-people-room.tsx
+++ b/mobile/src/people/current-people-room.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { NavigationRoute, NavigationScreenProp } from 'react-navigation';
-import { CurrentRoomNavigationParams } from '../employee-details/employee-details-dispatcher';
-import { EmployeesStore } from '../reducers/organization/employees.reducer';
-import { AppState } from '../reducers/app.reducer';
-import { connect } from 'react-redux';
-import { Employee } from '../reducers/organization/employee.model';
-import { PeopleRoom } from './people-room';
+import {NavigationRoute, NavigationScreenProp} from 'react-navigation';
+import {CurrentRoomNavigationParams} from '../employee-details/employee-details-dispatcher';
+import {EmployeesStore} from '../reducers/organization/employees.reducer';
+import {AppState} from '../reducers/app.reducer';
+import {connect} from 'react-redux';
+import {Employee} from '../reducers/organization/employee.model';
+import {PeopleRoom} from './people-room';
+import {Action, Dispatch} from 'redux';
+import {loadEmployeesForRoom} from '../reducers/organization/organization.action';
 
 interface ExtendedNavigationScreenProp<P> extends NavigationScreenProp<NavigationRoute> {
     getParam: <T extends keyof P>(param: T, fallback?: P[T]) => P[T];
@@ -19,11 +21,29 @@ interface CurrentPeopleRoomProps {
     employees: EmployeesStore;
 }
 
+interface CurrentPeopleDispatchProps {
+    loadEmployeesForRoom: (roomNumber: string) => void;
+}
+
 const mapStateToProps = (state: AppState): CurrentPeopleRoomProps => ({
     employees: state.organization.employees
 });
 
-class CurrentPeopleRoomImpl extends React.Component<CurrentPeopleRoomProps & NavigationProps> {
+const dispatchToProps = (dispatch: Dispatch<Action>) => {
+    return {
+        loadEmployeesForRoom: (roomNumber: string) => {
+            dispatch(loadEmployeesForRoom(roomNumber));
+        },
+    };
+};
+
+class CurrentPeopleRoomImpl extends React.Component<CurrentPeopleRoomProps & CurrentPeopleDispatchProps & NavigationProps> {
+
+    public componentDidMount() {
+        const roomNumber = this.props.navigation.getParam('roomNumber', undefined);
+        this.props.loadEmployeesForRoom(roomNumber);
+    }
+
     public render() {
         const roomNumber = this.props.navigation.getParam('roomNumber', undefined);
         const customEmployeesPredicate = (employee: Employee) => employee.roomNumber === roomNumber;
@@ -32,4 +52,4 @@ class CurrentPeopleRoomImpl extends React.Component<CurrentPeopleRoomProps & Nav
     }
 }
 
-export const CurrentPeopleRoom = connect(mapStateToProps)(CurrentPeopleRoomImpl);
+export const CurrentPeopleRoom = connect(mapStateToProps, dispatchToProps)(CurrentPeopleRoomImpl);


### PR DESCRIPTION
The previous implementation of CurrentPeopleRoom component filters employees list, on application start employees list contains only members of current user department, so if user opens his room he can't see members of other departments who belong to the same room.

Proposed solution: update employees list on room enter.