### PR TITLE
Persistent actors supervision

### DIFF
--- a/server/Arcadia.Assistant.Calendar/Arcadia.Assistant.Calendar.csproj
+++ b/server/Arcadia.Assistant.Calendar/Arcadia.Assistant.Calendar.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\Arcadia.Assistant.Notifications.Email\Arcadia.Assistant.Notifications.Email.csproj" />
     <ProjectReference Include="..\Arcadia.Assistant.Notifications\Arcadia.Assistant.Notifications.csproj" />
     <ProjectReference Include="..\Arcadia.Assistant.Organization.Abstractions\Arcadia.Assistant.Organization.Abstractions.csproj" />
+    <ProjectReference Include="..\Arcadia.Assistant.Patterns\Arcadia.Assistant.Patterns.csproj" />
   </ItemGroup>
 
 </Project>

--- a/server/Arcadia.Assistant.Calendar/SickLeave/EmployeeSickLeaveActor.cs
+++ b/server/Arcadia.Assistant.Calendar/SickLeave/EmployeeSickLeaveActor.cs
@@ -10,7 +10,6 @@
     using Arcadia.Assistant.Calendar.Abstractions;
     using Arcadia.Assistant.Calendar.Events;
     using Arcadia.Assistant.Organization.Abstractions;
-    using Arcadia.Assistant.Patterns;
 
     public class EmployeeSickLeaveActor : CalendarEventsStorageBase
     {

--- a/server/Arcadia.Assistant.Calendar/SickLeave/EmployeeSickLeaveActor.cs
+++ b/server/Arcadia.Assistant.Calendar/SickLeave/EmployeeSickLeaveActor.cs
@@ -24,7 +24,7 @@
 
         public static Props CreateProps(EmployeeMetadata employee, IActorRef calendarEventsApprovalsChecker)
         {
-            return new PersistenceSupervisorFactory().Get(Props.Create(() => new EmployeeSickLeaveActor(employee, calendarEventsApprovalsChecker)));
+            return Props.Create(() => new EmployeeSickLeaveActor(employee, calendarEventsApprovalsChecker));
         }
 
         protected override void OnRecover(object message)

--- a/server/Arcadia.Assistant.Calendar/SickLeave/EmployeeSickLeaveActor.cs
+++ b/server/Arcadia.Assistant.Calendar/SickLeave/EmployeeSickLeaveActor.cs
@@ -10,6 +10,7 @@
     using Arcadia.Assistant.Calendar.Abstractions;
     using Arcadia.Assistant.Calendar.Events;
     using Arcadia.Assistant.Organization.Abstractions;
+    using Arcadia.Assistant.Patterns;
 
     public class EmployeeSickLeaveActor : CalendarEventsStorageBase
     {
@@ -23,7 +24,7 @@
 
         public static Props CreateProps(EmployeeMetadata employee, IActorRef calendarEventsApprovalsChecker)
         {
-            return Props.Create(() => new EmployeeSickLeaveActor(employee, calendarEventsApprovalsChecker));
+            return new PersistenceSupervisorFactory().Get(Props.Create(() => new EmployeeSickLeaveActor(employee, calendarEventsApprovalsChecker)));
         }
 
         protected override void OnRecover(object message)

--- a/server/Arcadia.Assistant.Calendar/Vacations/EmployeeVacationsActor.cs
+++ b/server/Arcadia.Assistant.Calendar/Vacations/EmployeeVacationsActor.cs
@@ -5,7 +5,6 @@
     using System.Linq;
 
     using Akka.Actor;
-    using Akka.Pattern;
     using Akka.Persistence;
 
     using Arcadia.Assistant.Calendar.Abstractions;
@@ -14,7 +13,6 @@
     using Arcadia.Assistant.Feeds;
     using Arcadia.Assistant.Feeds.Messages;
     using Arcadia.Assistant.Organization.Abstractions;
-    using Arcadia.Assistant.Patterns;
 
     public class EmployeeVacationsActor : CalendarEventsStorageBase
     {

--- a/server/Arcadia.Assistant.Calendar/Vacations/EmployeeVacationsActor.cs
+++ b/server/Arcadia.Assistant.Calendar/Vacations/EmployeeVacationsActor.cs
@@ -5,6 +5,7 @@
     using System.Linq;
 
     using Akka.Actor;
+    using Akka.Pattern;
     using Akka.Persistence;
 
     using Arcadia.Assistant.Calendar.Abstractions;
@@ -13,6 +14,7 @@
     using Arcadia.Assistant.Feeds;
     using Arcadia.Assistant.Feeds.Messages;
     using Arcadia.Assistant.Organization.Abstractions;
+    using Arcadia.Assistant.Patterns;
 
     public class EmployeeVacationsActor : CalendarEventsStorageBase
     {
@@ -41,12 +43,14 @@
             IActorRef vacationsRegistry,
             IActorRef calendarEventsApprovalsChecker)
         {
-            return Props.Create(() => new EmployeeVacationsActor(
+            var childProps = Props.Create(() => new EmployeeVacationsActor(
                 employeeId,
                 employeeFeed,
                 vacationsRegistry,
                 calendarEventsApprovalsChecker)
             );
+
+            return new PersistenceSupervisorFactory().Get(childProps);
         }
 
         protected override void InsertCalendarEvent(

--- a/server/Arcadia.Assistant.Calendar/Vacations/EmployeeVacationsActor.cs
+++ b/server/Arcadia.Assistant.Calendar/Vacations/EmployeeVacationsActor.cs
@@ -43,14 +43,12 @@
             IActorRef vacationsRegistry,
             IActorRef calendarEventsApprovalsChecker)
         {
-            var childProps = Props.Create(() => new EmployeeVacationsActor(
+            return Props.Create(() => new EmployeeVacationsActor(
                 employeeId,
                 employeeFeed,
                 vacationsRegistry,
                 calendarEventsApprovalsChecker)
             );
-
-            return new PersistenceSupervisorFactory().Get(childProps);
         }
 
         protected override void InsertCalendarEvent(
@@ -113,14 +111,14 @@
                 }
 
                 var eventToPersist = new VacationDatesAreEdited
-                    {
-                        EventId = newEvent.EventId,
-                        StartDate = newEvent.Dates.StartDate,
-                        EndDate = newEvent.Dates.EndDate,
-                        TimeStamp = timestamp,
-                        UserId = updatedBy
-                    };
-                    this.Persist(eventToPersist, this.OnVacationDatesEdit);
+                {
+                    EventId = newEvent.EventId,
+                    StartDate = newEvent.Dates.StartDate,
+                    EndDate = newEvent.Dates.EndDate,
+                    TimeStamp = timestamp,
+                    UserId = updatedBy
+                };
+                this.Persist(eventToPersist, this.OnVacationDatesEdit);
             }
 
             if (oldEvent.Status != newEvent.Status)

--- a/server/Arcadia.Assistant.Calendar/WorkHours/EmployeeWorkHoursActor.cs
+++ b/server/Arcadia.Assistant.Calendar/WorkHours/EmployeeWorkHoursActor.cs
@@ -10,12 +10,13 @@
     using Arcadia.Assistant.Calendar.Abstractions;
     using Arcadia.Assistant.Calendar.Abstractions.Messages;
     using Arcadia.Assistant.Calendar.Events;
+    using Arcadia.Assistant.Patterns;
 
     public class EmployeeWorkHoursActor : CalendarEventsStorageBase
     {
         /// <summary>
         /// Positive values means that these days must be worked out.
-        /// Negative means that these can be taked as days off
+        /// Negative means that these can be taken as days off
         /// </summary>
         private int hoursCredit = 0;
 
@@ -27,7 +28,8 @@
 
         public static Props CreateProps(string employeeId, IActorRef calendarEventsApprovalsChecker)
         {
-            return Props.Create(() => new EmployeeWorkHoursActor(employeeId, calendarEventsApprovalsChecker));
+            return new PersistenceSupervisorFactory().Get(
+                Props.Create(() => new EmployeeWorkHoursActor(employeeId, calendarEventsApprovalsChecker)));
         }
 
         public override string PersistenceId { get; }

--- a/server/Arcadia.Assistant.Calendar/WorkHours/EmployeeWorkHoursActor.cs
+++ b/server/Arcadia.Assistant.Calendar/WorkHours/EmployeeWorkHoursActor.cs
@@ -28,8 +28,7 @@
 
         public static Props CreateProps(string employeeId, IActorRef calendarEventsApprovalsChecker)
         {
-            return new PersistenceSupervisorFactory().Get(
-                Props.Create(() => new EmployeeWorkHoursActor(employeeId, calendarEventsApprovalsChecker)));
+            return Props.Create(() => new EmployeeWorkHoursActor(employeeId, calendarEventsApprovalsChecker));
         }
 
         public override string PersistenceId { get; }

--- a/server/Arcadia.Assistant.Calendar/WorkHours/EmployeeWorkHoursActor.cs
+++ b/server/Arcadia.Assistant.Calendar/WorkHours/EmployeeWorkHoursActor.cs
@@ -10,7 +10,6 @@
     using Arcadia.Assistant.Calendar.Abstractions;
     using Arcadia.Assistant.Calendar.Abstractions.Messages;
     using Arcadia.Assistant.Calendar.Events;
-    using Arcadia.Assistant.Patterns;
 
     public class EmployeeWorkHoursActor : CalendarEventsStorageBase
     {

--- a/server/Arcadia.Assistant.Feeds/Arcadia.Assistant.Feeds.csproj
+++ b/server/Arcadia.Assistant.Feeds/Arcadia.Assistant.Feeds.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Arcadia.Assistant.Organization.Abstractions\Arcadia.Assistant.Organization.Abstractions.csproj" />
+    <ProjectReference Include="..\Arcadia.Assistant.Patterns\Arcadia.Assistant.Patterns.csproj" />
   </ItemGroup>
 
 </Project>

--- a/server/Arcadia.Assistant.Feeds/PersistentFeedActor.cs
+++ b/server/Arcadia.Assistant.Feeds/PersistentFeedActor.cs
@@ -1,13 +1,9 @@
 ﻿namespace Arcadia.Assistant.Feeds
 {
-    using System;
-
     using Akka.Actor;
-    using Akka.Pattern;
     using Akka.Persistence;
 
     using Arcadia.Assistant.Feeds.Messages;
-    using Arcadia.Assistant.Patterns;
 
     public class PersistentFeedActor : UntypedPersistentActor
     {

--- a/server/Arcadia.Assistant.Feeds/PersistentFeedActor.cs
+++ b/server/Arcadia.Assistant.Feeds/PersistentFeedActor.cs
@@ -1,9 +1,13 @@
 ﻿namespace Arcadia.Assistant.Feeds
 {
+    using System;
+
     using Akka.Actor;
+    using Akka.Pattern;
     using Akka.Persistence;
 
     using Arcadia.Assistant.Feeds.Messages;
+    using Arcadia.Assistant.Patterns;
 
     public class PersistentFeedActor : UntypedPersistentActor
     {
@@ -61,6 +65,9 @@
             this.internalFeed.Tell(new PostMessage(new Message(e.MessageId, e.EmployeeId, e.Title, e.Text, e.PostedDate)));
         }
 
-        public static Props CreateProps(string feedId) => Props.Create(() => new PersistentFeedActor(feedId));
+        public static Props CreateProps(string feedId)
+        {
+            return new PersistenceSupervisorFactory().Get(Props.Create(() => new PersistentFeedActor(feedId)));
+        }
     }
 }

--- a/server/Arcadia.Assistant.Feeds/PersistentFeedActor.cs
+++ b/server/Arcadia.Assistant.Feeds/PersistentFeedActor.cs
@@ -29,13 +29,13 @@
 
                     //TODO: Broadcast new message information to hubs/etc
                     var newEvent = new MessageIsPostedToFeedEvent()
-                        {
-                            MessageId = postMessage.Message.MessageId,
-                            EmployeeId = postMessage.Message.PostedByEmployeeId,
-                            PostedDate = postMessage.Message.DatePosted,
-                            Text = postMessage.Message.Text,
-                            Title = postMessage.Message.Title
-                        };
+                    {
+                        MessageId = postMessage.Message.MessageId,
+                        EmployeeId = postMessage.Message.PostedByEmployeeId,
+                        PostedDate = postMessage.Message.DatePosted,
+                        Text = postMessage.Message.Text,
+                        Title = postMessage.Message.Title
+                    };
 
                     this.Persist(newEvent, this.MessagePosted);
                     break;
@@ -65,9 +65,6 @@
             this.internalFeed.Tell(new PostMessage(new Message(e.MessageId, e.EmployeeId, e.Title, e.Text, e.PostedDate)));
         }
 
-        public static Props CreateProps(string feedId)
-        {
-            return new PersistenceSupervisorFactory().Get(Props.Create(() => new PersistentFeedActor(feedId)));
-        }
+        public static Props CreateProps(string feedId) => Props.Create(() => new PersistentFeedActor(feedId));
     }
 }

--- a/server/Arcadia.Assistant.Feeds/SharedFeedsActor.cs
+++ b/server/Arcadia.Assistant.Feeds/SharedFeedsActor.cs
@@ -7,6 +7,7 @@
 
     using Arcadia.Assistant.Feeds.Employees;
     using Arcadia.Assistant.Feeds.Messages;
+    using Arcadia.Assistant.Patterns;
 
     public class SharedFeedsActor : UntypedActor, ILogReceive
     {
@@ -22,8 +23,13 @@
 
         public SharedFeedsActor(IActorRef organization)
         {
-            var newsFeed = Context.ActorOf(PersistentFeedActor.CreateProps(NewsFeedId), NewsFeedId);
-            var systemFeed = Context.ActorOf(PersistentFeedActor.CreateProps(SystemFeedId), SystemFeedId);
+            var persistenceSupervisorFactory = new PersistenceSupervisorFactory();
+
+            var newsFeedActorProps = PersistentFeedActor.CreateProps(NewsFeedId);
+            var newsFeed = Context.ActorOf(persistenceSupervisorFactory.Get(newsFeedActorProps), NewsFeedId);
+
+            var systemFeedActorProps = PersistentFeedActor.CreateProps(SystemFeedId);
+            var systemFeed = Context.ActorOf(persistenceSupervisorFactory.Get(systemFeedActorProps), SystemFeedId);
 
             var birthdayFeed = Context.ActorOf(EmployeesBirthdaysFeedActor.CreateProps(organization), BirthdaysFeedId);
             var anniversariesFeed = Context.ActorOf(EmployeesAnniversariesFeedActor.CreateProps(organization), AnniversariesFeedId);

--- a/server/Arcadia.Assistant.Feeds/SharedFeedsActor.cs
+++ b/server/Arcadia.Assistant.Feeds/SharedFeedsActor.cs
@@ -1,6 +1,5 @@
 ﻿namespace Arcadia.Assistant.Feeds
 {
-    using System;
     using System.Collections.Generic;
 
     using Akka.Actor;

--- a/server/Arcadia.Assistant.Feeds/SharedFeedsActor.cs
+++ b/server/Arcadia.Assistant.Feeds/SharedFeedsActor.cs
@@ -22,8 +22,8 @@
 
         public SharedFeedsActor(IActorRef organization)
         {
-            var newsFeed = Context.ActorOf(Props.Create(() => new PersistentFeedActor(NewsFeedId)), NewsFeedId);
-            var systemFeed = Context.ActorOf(Props.Create(() => new PersistentFeedActor(SystemFeedId)), SystemFeedId);
+            var newsFeed = Context.ActorOf(PersistentFeedActor.CreateProps(NewsFeedId), NewsFeedId);
+            var systemFeed = Context.ActorOf(PersistentFeedActor.CreateProps(SystemFeedId), SystemFeedId);
 
             var birthdayFeed = Context.ActorOf(EmployeesBirthdaysFeedActor.CreateProps(organization), BirthdaysFeedId);
             var anniversariesFeed = Context.ActorOf(EmployeesAnniversariesFeedActor.CreateProps(organization), AnniversariesFeedId);

--- a/server/Arcadia.Assistant.Notifications.Push/Arcadia.Assistant.Notifications.Push.csproj
+++ b/server/Arcadia.Assistant.Notifications.Push/Arcadia.Assistant.Notifications.Push.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Arcadia.Assistant.Configuration\Arcadia.Assistant.Configuration.csproj" />
+    <ProjectReference Include="..\Arcadia.Assistant.Patterns\Arcadia.Assistant.Patterns.csproj" />
   </ItemGroup>
 
 </Project>

--- a/server/Arcadia.Assistant.Notifications.Push/PushNotificationsDevicesActor.cs
+++ b/server/Arcadia.Assistant.Notifications.Push/PushNotificationsDevicesActor.cs
@@ -19,7 +19,7 @@
 
         public static Props CreateProps()
         {
-            return new PersistenceSupervisorFactory().Get(Props.Create(() => new PushNotificationsDevicesActor()));
+            return Props.Create(() => new PushNotificationsDevicesActor());
         }
 
         protected override void OnCommand(object message)

--- a/server/Arcadia.Assistant.Notifications.Push/PushNotificationsDevicesActor.cs
+++ b/server/Arcadia.Assistant.Notifications.Push/PushNotificationsDevicesActor.cs
@@ -8,6 +8,7 @@
     using Akka.Persistence;
 
     using Arcadia.Assistant.Notifications.Push.Events;
+    using Arcadia.Assistant.Patterns;
 
     public class PushNotificationsDevicesActor : UntypedPersistentActor, ILogReceive
     {
@@ -15,6 +16,11 @@
         private readonly Dictionary<string, string> deviceTypeByToken = new Dictionary<string, string>();
 
         public override string PersistenceId => "push-notifications-devices";
+
+        public static Props CreateProps()
+        {
+            return new PersistenceSupervisorFactory().Get(Props.Create(() => new PushNotificationsDevicesActor()));
+        }
 
         protected override void OnCommand(object message)
         {

--- a/server/Arcadia.Assistant.Notifications.Push/PushNotificationsDevicesActor.cs
+++ b/server/Arcadia.Assistant.Notifications.Push/PushNotificationsDevicesActor.cs
@@ -8,7 +8,6 @@
     using Akka.Persistence;
 
     using Arcadia.Assistant.Notifications.Push.Events;
-    using Arcadia.Assistant.Patterns;
 
     public class PushNotificationsDevicesActor : UntypedPersistentActor, ILogReceive
     {

--- a/server/Arcadia.Assistant.Organization/EmployeeActor.cs
+++ b/server/Arcadia.Assistant.Organization/EmployeeActor.cs
@@ -16,6 +16,7 @@
     using Arcadia.Assistant.Organization.Abstractions;
     using Arcadia.Assistant.Organization.Abstractions.OrganizationRequests;
     using Arcadia.Assistant.Organization.Events;
+    using Arcadia.Assistant.Patterns;
 
     public class EmployeeActor : UntypedPersistentActor, ILogReceive
     {
@@ -212,14 +213,12 @@
             }
         }
 
-        public static Props GetProps(EmployeeStoredInformation employeeStoredInformation,
-            IActorRef imageResizer,
-            IActorRef vacationsRegistry,
-            IActorRef calendarEventsApprovalsChecker
-        ) => Props.Create(() => new EmployeeActor(
-            employeeStoredInformation,
-            imageResizer,
-            vacationsRegistry,
-            calendarEventsApprovalsChecker));
+        public static Props GetProps(EmployeeStoredInformation employeeStoredInformation, IActorRef imageResizer, IActorRef vacationsRegistry, IActorRef calendarEventsApprovalsChecker)
+        {
+            var childProps = Props.Create(() => 
+                new EmployeeActor(employeeStoredInformation, imageResizer, vacationsRegistry, calendarEventsApprovalsChecker));
+
+            return new PersistenceSupervisorFactory().Get(childProps);
+        }
     }
 }

--- a/server/Arcadia.Assistant.Patterns/Arcadia.Assistant.Patterns.csproj
+++ b/server/Arcadia.Assistant.Patterns/Arcadia.Assistant.Patterns.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Akka" Version="1.3.10" />
+  </ItemGroup>
+
+</Project>

--- a/server/Arcadia.Assistant.Patterns/PersistenceSupervisorFactory.cs
+++ b/server/Arcadia.Assistant.Patterns/PersistenceSupervisorFactory.cs
@@ -1,0 +1,23 @@
+﻿namespace Arcadia.Assistant.Patterns
+{
+    using System;
+
+    using Akka.Actor;
+    using Akka.Pattern;
+
+    public class PersistenceSupervisorFactory
+    {
+        public string ChildName { get; set; } = "persist";
+
+        public TimeSpan MinBackoff { get; set; } = TimeSpan.FromSeconds(5);
+
+        public TimeSpan MaxBackoff { get; set; } = TimeSpan.FromSeconds(30);
+
+        public double RandomFactor { get; set; } = 0.2;
+
+        public Props Get(Props childProps)
+        {
+            return BackoffSupervisor.Props(Backoff.OnStop(childProps, this.ChildName, this.MinBackoff, this.MaxBackoff, this.RandomFactor));
+        }
+    }
+}

--- a/server/Arcadia.Assistant.Server/ActorSystemBuilder.cs
+++ b/server/Arcadia.Assistant.Server/ActorSystemBuilder.cs
@@ -36,9 +36,17 @@
             var helpdesk = this.actorSystem.ActorOf(Props.Create(() => new HelpdeskActor()), WellKnownActorPaths.Helpdesk);
             var feeds = this.actorSystem.ActorOf(Props.Create(() => new SharedFeedsActor(organization)), WellKnownActorPaths.SharedFeeds);
 
+            var persistenceSupervisorFactory = new PersistenceSupervisorFactory();
+
             var userPreferenceActorProps = this.actorSystem.DI().Props<UserPreferencesActor>();
-            var userPreferences = this.actorSystem.ActorOf(new PersistenceSupervisorFactory().Get(userPreferenceActorProps), WellKnownActorPaths.UserPreferences);
-            var pushNotificationsDevices = this.actorSystem.ActorOf(PushNotificationsDevicesActor.CreateProps(), WellKnownActorPaths.PushNotificationsDevices);
+            var userPreferences = this.actorSystem.ActorOf(
+                persistenceSupervisorFactory.Get(userPreferenceActorProps),
+                WellKnownActorPaths.UserPreferences);
+
+            var pushNotificationsDevicesActorProps = PushNotificationsDevicesActor.CreateProps();
+            var pushNotificationsDevices = this.actorSystem.ActorOf(
+                persistenceSupervisorFactory.Get(pushNotificationsDevicesActorProps),
+                WellKnownActorPaths.PushNotificationsDevices);
 
             var inboxEmailsActor = this.actorSystem.ActorOf(this.actorSystem.DI().Props<InboxEmailActor>(), "inbox-emails");
             this.actorSystem.ActorOf(Props.Create(() => new InboxEmailsNotificator(imapSettings, inboxEmailsActor)), "emails-notificator");

--- a/server/Arcadia.Assistant.Server/ActorSystemBuilder.cs
+++ b/server/Arcadia.Assistant.Server/ActorSystemBuilder.cs
@@ -13,6 +13,7 @@
     using Arcadia.Assistant.Notifications.Email;
     using Arcadia.Assistant.Notifications.Push;
     using Arcadia.Assistant.Organization;
+    using Arcadia.Assistant.Patterns;
     using Arcadia.Assistant.Server.Interop;
     using Arcadia.Assistant.UserPreferences;
 
@@ -34,8 +35,10 @@
             var health = this.actorSystem.ActorOf(this.actorSystem.DI().Props<HealthChecker>(), WellKnownActorPaths.Health);
             var helpdesk = this.actorSystem.ActorOf(Props.Create(() => new HelpdeskActor()), WellKnownActorPaths.Helpdesk);
             var feeds = this.actorSystem.ActorOf(Props.Create(() => new SharedFeedsActor(organization)), WellKnownActorPaths.SharedFeeds);
-            var userPreferences = this.actorSystem.ActorOf(this.actorSystem.DI().Props<UserPreferencesActor>(), WellKnownActorPaths.UserPreferences);
-            var pushNotificationsDevices = this.actorSystem.ActorOf(Props.Create(() => new PushNotificationsDevicesActor()), WellKnownActorPaths.PushNotificationsDevices);
+
+            var userPreferenceActorProps = this.actorSystem.DI().Props<UserPreferencesActor>();
+            var userPreferences = this.actorSystem.ActorOf(new PersistenceSupervisorFactory().Get(userPreferenceActorProps), WellKnownActorPaths.UserPreferences);
+            var pushNotificationsDevices = this.actorSystem.ActorOf(PushNotificationsDevicesActor.CreateProps(), WellKnownActorPaths.PushNotificationsDevices);
 
             var inboxEmailsActor = this.actorSystem.ActorOf(this.actorSystem.DI().Props<InboxEmailActor>(), "inbox-emails");
             this.actorSystem.ActorOf(Props.Create(() => new InboxEmailsNotificator(imapSettings, inboxEmailsActor)), "emails-notificator");

--- a/server/Arcadia.Assistant.sln
+++ b/server/Arcadia.Assistant.sln
@@ -59,9 +59,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcadia.Assistant.Calendar.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcadia.Assistant.Notifications.Push", "Arcadia.Assistant.Notifications.Push\Arcadia.Assistant.Notifications.Push.csproj", "{79594908-4475-4287-A0C2-3BD1D82BF615}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcadia.Assistant.InboxEmail", "Arcadia.Assistant.InboxEmail\Arcadia.Assistant.InboxEmail.csproj", "{C77FED76-B322-4172-9BB4-69568D0B80F0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcadia.Assistant.InboxEmail", "Arcadia.Assistant.InboxEmail\Arcadia.Assistant.InboxEmail.csproj", "{C77FED76-B322-4172-9BB4-69568D0B80F0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcadia.Assistant.InboxEmail.Abstractions", "Arcadia.Assistant.InboxEmail.Abstractions\Arcadia.Assistant.InboxEmail.Abstractions.csproj", "{C23EEEFF-4912-469B-AA8E-CF5EAE22ECBC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcadia.Assistant.InboxEmail.Abstractions", "Arcadia.Assistant.InboxEmail.Abstractions\Arcadia.Assistant.InboxEmail.Abstractions.csproj", "{C23EEEFF-4912-469B-AA8E-CF5EAE22ECBC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcadia.Assistant.Patterns", "Arcadia.Assistant.Patterns\Arcadia.Assistant.Patterns.csproj", "{44B9A684-2DB5-41DE-8643-63D3432C1B8F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -170,6 +172,10 @@ Global
 		{C23EEEFF-4912-469B-AA8E-CF5EAE22ECBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C23EEEFF-4912-469B-AA8E-CF5EAE22ECBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C23EEEFF-4912-469B-AA8E-CF5EAE22ECBC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44B9A684-2DB5-41DE-8643-63D3432C1B8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44B9A684-2DB5-41DE-8643-63D3432C1B8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44B9A684-2DB5-41DE-8643-63D3432C1B8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44B9A684-2DB5-41DE-8643-63D3432C1B8F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Related bug: if journal database is unavailable, persist method doesn't throw any exceptions. That's why server will always successfully return, even if real persist didn't take place.