### PR TITLE
#455 Company view: Employee photo don't fit in the photo area

### DIFF
--- a/mobile/src/people/company-departments-level-animated-node.tsx
+++ b/mobile/src/people/company-departments-level-animated-node.tsx
@@ -156,12 +156,14 @@ interface CompanyDepartmentsLevelAnimatedNodeProps {
 
 export class CompanyDepartmentsLevelAnimatedNode extends Component<CompanyDepartmentsLevelAnimatedNodeProps> {
     private readonly animatedContainerOpacity = new Animated.Value(0);
-    private readonly isAndroid70: boolean = false;
+    private readonly isAndroid7x: boolean = false;
 
     constructor(props: CompanyDepartmentsLevelAnimatedNodeProps, context: any) {
         super(props, context);
 
-        this.isAndroid70 = Platform.OS === 'android' && Platform.Version === 24;
+        this.isAndroid7x = Platform.OS === 'android' &&
+            (Platform.Version === 24 ||
+             Platform.Version === 25);
     }
 
     public shouldComponentUpdate(nextProps: CompanyDepartmentsLevelAnimatedNodeProps) {
@@ -298,6 +300,6 @@ export class CompanyDepartmentsLevelAnimatedNode extends Component<CompanyDepart
     };
 
     private scaleAnimationSupported = (): boolean => {
-        return !this.isAndroid70;
+        return !this.isAndroid7x;
     };
 }

--- a/mobile/src/people/styles.tsx
+++ b/mobile/src/people/styles.tsx
@@ -81,7 +81,8 @@ export const companyDepartmentsAnimatedNode = StyleSheet.create({
     stickyContainer: {
         justifyContent: 'center',
         alignItems: 'center',
-        zIndex: 1
+        zIndex: 1,
+        alignSelf: 'center',
     },
     scaleContainer: {
         justifyContent: 'center',


### PR DESCRIPTION
Scale transformation (either animated or not) corrupts FastImage for some reason on Android 7.0.0.
Scale animation is disabled on Android 7.0.0 devices.