### PR TITLE
#471: Support 'processed' vacations

### DIFF
--- a/mobile/src/calendar/calendar-legend.tsx
+++ b/mobile/src/calendar/calendar-legend.tsx
@@ -7,6 +7,7 @@ import { CalendarEventsColor, legendStyles as styles } from './styles';
 import { StyledText } from '../override/styled-text';
 import { Optional } from 'types';
 import moment from 'moment';
+import { CalendarEvent } from '../reducers/calendar/calendar-event.model';
 
 //============================================================================
 interface CalendarLegendProps {
@@ -19,12 +20,18 @@ class CalendarLegendImpl extends Component<CalendarLegendProps> {
     //----------------------------------------------------------------------------
     public render() {
         const selectedEvents = this.getEventsForSelectedDate();
-        const legend = selectedEvents.map((type, index) => {
-            const style = StyleSheet.flatten([styles.marker, { backgroundColor: CalendarEventsColor.getColor(type) }]);
+        const legend = selectedEvents.map((event, index) => {
+            const style = StyleSheet.flatten(
+                [
+                    styles.marker,
+                    { backgroundColor: CalendarEventsColor.getColor(event.type) },
+                ]
+            );
+
             return (
-                <View key={type + index} style={styles.itemContainer}>
+                <View key={event.type + index} style={styles.itemContainer}>
                     <View style={style}/>
-                    <StyledText style={styles.label}>{type}</StyledText>
+                    <StyledText style={styles.label}>{event.type}</StyledText>
                 </View>
             );
         });
@@ -39,14 +46,14 @@ class CalendarLegendImpl extends Component<CalendarLegendProps> {
     }
 
     //----------------------------------------------------------------------------
-    private getEventsForSelectedDate() {
+    private getEventsForSelectedDate(): CalendarEvent[] {
         const { intervals, selectedDay } = this.props;
 
         if (!selectedDay || !intervals) {
             return [];
         }
 
-        return (intervals.get(selectedDay.date) || []).map(interval => interval.calendarEvent.type);
+        return (intervals.get(selectedDay.date) || []).map(interval => interval.calendarEvent);
     }
 }
 

--- a/mobile/src/calendar/calendar-page.tsx
+++ b/mobile/src/calendar/calendar-page.tsx
@@ -255,7 +255,7 @@ export class CalendarPage extends PureComponent<CalendarPageDefaultProps & Calen
 
     //----------------------------------------------------------------------------
     private renderInterval(interval: IntervalModel, elementKey: number): JSX.Element | null {
-        const color = CalendarEventsColor.getColor(interval.calendarEvent.type) || '#fff';
+        const color = CalendarEventsColor.getColor(interval.calendarEvent.type, interval.calendarEvent.status) || '#FFFFFF';
 
         switch (interval.intervalType) {
             case IntervalType.StartInterval:

--- a/mobile/src/calendar/calendar-page.tsx
+++ b/mobile/src/calendar/calendar-page.tsx
@@ -255,7 +255,7 @@ export class CalendarPage extends PureComponent<CalendarPageDefaultProps & Calen
 
     //----------------------------------------------------------------------------
     private renderInterval(interval: IntervalModel, elementKey: number): JSX.Element | null {
-        const color = CalendarEventsColor.getColor(interval.calendarEvent.type, interval.calendarEvent.status) || '#FFFFFF';
+        const color = CalendarEventsColor.getColor(interval.calendarEvent.type, interval.calendarEvent.status) || Style.color.white;
 
         switch (interval.intervalType) {
             case IntervalType.StartInterval:

--- a/mobile/src/calendar/styles.ts
+++ b/mobile/src/calendar/styles.ts
@@ -1,5 +1,5 @@
 import { PixelRatio, StyleSheet } from 'react-native';
-import { CalendarEventType } from '../reducers/calendar/calendar-event.model';
+import { CalendarEventStatus, CalendarEventType } from '../reducers/calendar/calendar-event.model';
 
 const daysCounterTitleColor = '#18515E';
 
@@ -116,23 +116,48 @@ export class CalendarEventsColor {
     public static dayoff = '#EB5757';
     public static workout = '#219653';
 
-    public static getColor(type: CalendarEventType) {
+    private static noOpacity = '';
+    private static processedOpacity = '80';
+
+    public static getColor(type: CalendarEventType, status?: CalendarEventStatus) {
+        let color: string = CalendarEventsColor.defaultColor;
+
         switch (type) {
             case CalendarEventType.Vacation:
-                return CalendarEventsColor.vacation;
+                color = CalendarEventsColor.vacation;
+                break;
 
             case CalendarEventType.Sickleave:
-                return CalendarEventsColor.sickLeave;
+                color = CalendarEventsColor.sickLeave;
+                break;
 
             case CalendarEventType.Dayoff:
-                return CalendarEventsColor.dayoff;
+                color = CalendarEventsColor.dayoff;
+                break;
 
             case CalendarEventType.Workout:
-                return CalendarEventsColor.workout;
+                color = CalendarEventsColor.workout;
+                break;
 
             default:
-                return CalendarEventsColor.defaultColor;
+                color = CalendarEventsColor.defaultColor;
+                break;
         }
+
+        return color.concat(CalendarEventsColor.getOpacity(type, status));
+    }
+
+    private static getOpacity(type: CalendarEventType, status?: CalendarEventStatus) {
+        if (!status) {
+            return this.noOpacity;
+        }
+
+        if (type === CalendarEventType.Vacation &&
+            status === CalendarEventStatus.Processed) {
+            return this.processedOpacity;
+        }
+
+        return this.noOpacity;
     }
 }
 

--- a/mobile/src/employee-details/event-action-provider.ts
+++ b/mobile/src/employee-details/event-action-provider.ts
@@ -86,12 +86,18 @@ export class EventActionProvider {
                            permissions: UserEmployeePermissions,
                            approvals: Map<CalendarEventId, Set<Approval>>): Optional<EventAction> {
 
-        const eventStatusRequested = event.status === CalendarEventStatus.Requested;
-        const permissionApprove = permissions.has(Permission.approveCalendarEvents);
-        const approvedByMe = this.approvedByMe(event, approvals);
+        switch (event.status) {
+            case CalendarEventStatus.Requested:
+                const permissionApprove = permissions.has(Permission.approveCalendarEvents);
+                const approvedByMe = this.approvedByMe(event, approvals);
 
-        if (eventStatusRequested && permissionApprove && !approvedByMe) {
-            return this.approveAction(event, employee);
+                if (permissionApprove && !approvedByMe) {
+                    return this.approveAction(event, employee);
+                }
+                break;
+
+            default:
+                break;
         }
 
         return undefined;

--- a/mobile/src/reducers/calendar/calendar-event.model.ts
+++ b/mobile/src/reducers/calendar/calendar-event.model.ts
@@ -5,7 +5,7 @@ export enum CalendarEventType {
     Vacation = 'Vacation',
     Sickleave = 'Sickleave',
     Dayoff = 'Dayoff',
-    Workout = 'Workout'
+    Workout = 'Workout',
 }
 
 export enum CalendarEventStatus {
@@ -13,7 +13,8 @@ export enum CalendarEventStatus {
     Completed = 'Completed',
     Cancelled = 'Cancelled',
     Approved = 'Approved',
-    Rejected = 'Rejected'
+    Rejected = 'Rejected',
+    Processed = 'Processed',
 }
 
 export class DatesInterval {

--- a/mobile/src/reducers/calendar/calendar-events.model.ts
+++ b/mobile/src/reducers/calendar/calendar-events.model.ts
@@ -79,6 +79,7 @@ export class CalendarEvents {
         intervalsModel.intervalsMetadata.addCalendarEvent(calendarEvent);
     }
 
+    // noinspection JSMethodCanBeStatic
     private getBoundaryType(calendarEvent: CalendarEvent): IntervalType | null {
         const { startWorkingHour, finishWorkingHour } = calendarEvent.dates;
 


### PR DESCRIPTION
1. Current implementation already doesn’t allow actions if event is not ‘Requested’ or ‘Approved’, no actions are required to support ‘Processed’ status
2. Processed vacations are renders with 50% opacity on the calendar
3. Color in the legend is not changed