### PR TITLE
finishWorkingHour is to be between 1 and 24

### DIFF
--- a/mobile/src/reducers/calendar/calendar-event.model.ts
+++ b/mobile/src/reducers/calendar/calendar-event.model.ts
@@ -38,7 +38,7 @@ export class DatesInterval {
 
     @dataMember()
     @required()
-    public finishWorkingHour: number = 0;
+    public finishWorkingHour: number = 8;
 
     public toJSON(): Object {
         const overrided: { [key in keyof DatesInterval]?: any } = {


### PR DESCRIPTION
#492 'Prolong sick leave' feature fails with 400 error
#444 Calendar view: user can't edit vacation dates

When new DatesInterval is created, both startWorkingHour and finishWorkingHour are set to 0, while server requires finishWorkingHour to be between 1 and 24. Set it to be 8 by default.