### PR TITLE
Send sick leave notification only if current status is approved, but previous status is not approved.

### DIFF
--- a/server/Arcadia.Assistant.Calendar.Notifications/SickLeaveApprovedEmailNotificationActor.cs
+++ b/server/Arcadia.Assistant.Calendar.Notifications/SickLeaveApprovedEmailNotificationActor.cs
@@ -35,7 +35,8 @@
             {
                 case CalendarEventChanged msg
                     when msg.NewEvent.Type == CalendarEventTypes.Sickleave &&
-                    msg.NewEvent.Status == SickLeaveStatuses.Approved:
+                    msg.NewEvent.Status == SickLeaveStatuses.Approved &&
+                    msg.OldEvent.Status != SickLeaveStatuses.Approved:
 
                     this.organizationActor
                         .Ask<EmployeesQuery.Response>(EmployeesQuery.Create().WithId(msg.NewEvent.EmployeeId))


### PR DESCRIPTION
Issue #505 