### PR TITLE
Simple fix for long room names

### DIFF
--- a/mobile/src/employee-details/employee-details.tsx
+++ b/mobile/src/employee-details/employee-details.tsx
@@ -273,7 +273,7 @@ export class EmployeeDetailsImpl extends Component<EmployeeDetailsProps & Employ
                 onPress: null
             },
             {
-                label: `Room ${employee.roomNumber}`,
+                label: `Room`,
                 icon: 'office',
                 style: StyleSheet.flatten([tileStyles.icon]),
                 size: 25,

--- a/mobile/src/employee-details/employee-details.tsx
+++ b/mobile/src/employee-details/employee-details.tsx
@@ -255,6 +255,9 @@ export class EmployeeDetailsImpl extends Component<EmployeeDetailsProps & Employ
 
     //----------------------------------------------------------------------------
     private getTiles(employee: Employee) {
+        let roomNumber = employee && employee.roomNumber ? employee.roomNumber : '';
+        let roomTitle: string = isNaN(Number(roomNumber)) ? roomNumber : `Room ${roomNumber}`;
+
         const tilesData: TileData[] = [
             {
                 label: employee.birthDate.format('MMMM D'),
@@ -273,7 +276,7 @@ export class EmployeeDetailsImpl extends Component<EmployeeDetailsProps & Employ
                 onPress: null
             },
             {
-                label: `Room`,
+                label: roomTitle,
                 icon: 'office',
                 style: StyleSheet.flatten([tileStyles.icon]),
                 size: 25,

--- a/mobile/src/people/navigator/tab-bar-top-custom.component.tsx
+++ b/mobile/src/people/navigator/tab-bar-top-custom.component.tsx
@@ -38,7 +38,7 @@ class TabBarTopCustomImpl extends React.Component<TabBarTopProps & TabBarTopCust
             case 'Department':
                 return department ? department.abbreviation : 'Department';
             case 'Room':
-                return employee ? `Room ${employee.roomNumber}` : 'Room';
+                return 'Room';
             case 'Company':
                 return 'Company';
             default:

--- a/mobile/src/people/navigator/tab-bar-top-custom.component.tsx
+++ b/mobile/src/people/navigator/tab-bar-top-custom.component.tsx
@@ -34,11 +34,14 @@ class TabBarTopCustomImpl extends React.Component<TabBarTopProps & TabBarTopCust
     //----------------------------------------------------------------------------
     private getLabel = (param: TabLabelTextParam, employee: Nullable<Employee>, department: Nullable<Department>): string => {
 
+        let roomNumber = employee && employee.roomNumber ? employee.roomNumber : '';
+        let roomTitle: string = isNaN(Number(roomNumber)) ? roomNumber : `Room ${roomNumber}`;
+
         switch (param.route.key) {
             case 'Department':
-                return 'Department';
+                return department ? department.abbreviation : 'Department';
             case 'Room':
-                return 'Room';
+                return roomTitle;
             case 'Company':
                 return 'Company';
             default:

--- a/mobile/src/people/navigator/tab-bar-top-custom.component.tsx
+++ b/mobile/src/people/navigator/tab-bar-top-custom.component.tsx
@@ -3,10 +3,12 @@ import { Employee } from '../../reducers/organization/employee.model';
 import { Department } from '../../reducers/organization/department.model';
 import { MaterialTopTabBar, TabBarTopProps, TabLabelTextParam } from 'react-navigation';
 import { connect } from 'react-redux';
-import { AppState } from '../../reducers/app.reducer';
+import { AppState, getEmployee } from '../../reducers/app.reducer';
 import { Nullable, Optional } from 'types';
-import { getEmployee } from '../../reducers/app.reducer';
 import { toNullable } from '../../types/types-utils';
+import { StyledText } from '../../override/styled-text';
+import tabBarStyles from '../../tabbar/tab-bar-styles';
+import { StyleSheet } from 'react-native';
 
 //============================================================================
 interface TabBarTopCustomProps {
@@ -32,21 +34,38 @@ class TabBarTopCustomImpl extends React.Component<TabBarTopProps & TabBarTopCust
     }
 
     //----------------------------------------------------------------------------
-    private getLabel = (param: TabLabelTextParam, employee: Nullable<Employee>, department: Nullable<Department>): string => {
+    private getLabel = (param: TabLabelTextParam, employee: Nullable<Employee>, department: Nullable<Department>): React.ReactNode | string => {
 
-        let roomNumber = employee && employee.roomNumber ? employee.roomNumber : '';
-        let roomTitle: string = isNaN(Number(roomNumber)) ? roomNumber : `Room ${roomNumber}`;
+        const roomNumber = employee && employee.roomNumber ? employee.roomNumber : '';
+        const roomTitle: string = isNaN(Number(roomNumber)) ? roomNumber : `Room ${roomNumber}`;
+        let label = '';
 
         switch (param.route.key) {
             case 'Department':
-                return department ? department.abbreviation : 'Department';
+                label = department ? department.abbreviation : 'Department';
+                break;
             case 'Room':
-                return roomTitle;
+                label = roomTitle;
+                break;
             case 'Company':
-                return 'Company';
+                label = 'Company';
+                break;
             default:
-                return '';
+                break;
         }
+
+        const style = StyleSheet.flatten([
+            tabBarStyles.tabBarLabel,
+            {
+                fontSize: 12,
+                marginBottom: 0,
+            },
+        ]);
+        return (
+            <StyledText numberOfLines={1} ellipsizeMode={'tail'} style={style}>
+                {label}
+            </StyledText>
+        );
     };
 }
 

--- a/mobile/src/people/navigator/tab-bar-top-custom.component.tsx
+++ b/mobile/src/people/navigator/tab-bar-top-custom.component.tsx
@@ -36,7 +36,7 @@ class TabBarTopCustomImpl extends React.Component<TabBarTopProps & TabBarTopCust
 
         switch (param.route.key) {
             case 'Department':
-                return department ? department.abbreviation : 'Department';
+                return 'Department';
             case 'Room':
                 return 'Room';
             case 'Company':

--- a/mobile/src/types/react-navigation.d.ts
+++ b/mobile/src/types/react-navigation.d.ts
@@ -1048,7 +1048,7 @@ declare module 'react-navigation' {
         tabBarPosition: string;
         navigation: NavigationScreenProp<NavigationState>;
         jumpToIndex: (index: number) => void;
-        getLabelText: (r: TabLabelTextParam) => string;
+        getLabelText: (r: TabLabelTextParam) => React.ReactNode | string;
         getOnPress: (
             previousScene: NavigationRoute,
             scene: TabScene


### PR DESCRIPTION
Room detailed info replaced with simple “Room” title on tabs