### PR TITLE
Stick to selected sick-leave in edit mode

### DIFF
--- a/mobile/src/reducers/calendar/event-dialog/event-dialog.epics.ts
+++ b/mobile/src/reducers/calendar/event-dialog/event-dialog.epics.ts
@@ -33,7 +33,7 @@ export const openEventDialogEpic$ = (action$: ActionsObservable<OpenEventDialog>
                     return calendarSelectionMode(CalendarSelectionModeType.Interval, CalendarEventsColor.sickLeave);
 
                 case EventDialogType.EditSickLeave:
-                    return [calendarSelectionMode(CalendarSelectionModeType.SingleDay), disableCalendarSelection(true)];
+                    return [calendarSelectionMode(CalendarSelectionModeType.SingleDay), disableCalendarSelection(true), disableSelectIntervalsBySingleDaySelection(true)];
 
                 case EventDialogType.ProlongSickLeave:
                     return calendarSelectionMode(CalendarSelectionModeType.Interval, CalendarEventsColor.sickLeave);


### PR DESCRIPTION
If user have selected Edit for some sick leave any other sick leaves couldn’t be selected until edit mode is active (so user have to either close Edit sick leave popup or make available changes - Prolong or Complete).