### PR TITLE
Sick leaves Sharepoint fix

### DIFF
--- a/server/Arcadia.Assistant.CSP/Sharepoint/SharepointActor.cs
+++ b/server/Arcadia.Assistant.CSP/Sharepoint/SharepointActor.cs
@@ -20,7 +20,7 @@
 
         private readonly ISharepointDepartmentsCalendarsSettings departmentsCalendarsSettings;
         private readonly ActorSelection organizationActor;
-        private IActorRef sharepointStorageActor;
+        private readonly IActorRef sharepointStorageActor;
 
         private readonly ILoggingAdapter logger = Context.GetLogger();
 
@@ -30,6 +30,7 @@
             this.organizationActor = Context.ActorSelection(OrganizationActorPath);
 
             Context.System.EventStream.Subscribe<CalendarEventRecoverComplete>(this.Self);
+            Context.System.EventStream.Subscribe<CalendarEventCreated>(this.Self);
             Context.System.EventStream.Subscribe<CalendarEventChanged>(this.Self);
             Context.System.EventStream.Subscribe<CalendarEventRemoved>(this.Self);
 
@@ -46,6 +47,10 @@
             switch (message)
             {
                 case CalendarEventRecoverComplete msg:
+                    this.OnReceiveEvent(msg.Event);
+                    break;
+
+                case CalendarEventCreated msg:
                     this.OnReceiveEvent(msg.Event);
                     break;
 

--- a/server/Arcadia.Assistant.Calendar.Abstractions/CalendarEventStatuses.cs
+++ b/server/Arcadia.Assistant.Calendar.Abstractions/CalendarEventStatuses.cs
@@ -16,7 +16,6 @@
         {
             { CalendarEventTypes.Dayoff, WorkHoursChangeStatuses.Pending },
             { CalendarEventTypes.Workout, WorkHoursChangeStatuses.Pending },
-            { CalendarEventTypes.Sickleave, SickLeaveStatuses.Pending },
             { CalendarEventTypes.Vacation, VacationStatuses.Pending }
         };
 

--- a/server/Arcadia.Assistant.Calendar.Abstractions/SickLeaveStatuses.cs
+++ b/server/Arcadia.Assistant.Calendar.Abstractions/SickLeaveStatuses.cs
@@ -10,8 +10,6 @@
 
         public static readonly string[] All = { Requested, Completed, Cancelled };
 
-        public static readonly string[] Pending = new string[0];
-
         public static readonly string[] Actual = { Requested, Completed };
     }
 }

--- a/server/Arcadia.Assistant.Calendar.Abstractions/SickLeaveStatuses.cs
+++ b/server/Arcadia.Assistant.Calendar.Abstractions/SickLeaveStatuses.cs
@@ -10,7 +10,7 @@
 
         public static readonly string[] All = { Requested, Completed, Cancelled };
 
-        public static readonly string[] Pending = { Requested };
+        public static readonly string[] Pending = new string[0];
 
         public static readonly string[] Actual = { Requested, Completed };
     }


### PR DESCRIPTION
Issue #747 

Sharepoint will watch also for calendar event created events, because sick leaves should be stored to Sharpoint right after their creation.